### PR TITLE
Improve random32/random64(max:) with small max

### DIFF
--- a/CwlUtils/CwlRandom.swift
+++ b/CwlUtils/CwlRandom.swift
@@ -59,20 +59,53 @@ extension RandomGenerator {
 		randomize(&bits, size: sizeof(UInt32))
 		return bits
 	}
+	
+	/* random64(max:) and random32(max:) are reimplementations of OpenBSD's arc4random_uniform, which is:
+
+	Copyright (c) 2008, Damien Miller <djm@openbsd.org>
+	
+	Permission to use, copy, modify, and distribute this software for any
+	purpose with or without fee is hereby granted, provided that the above
+	copyright notice and this permission notice appear in all copies.
+	
+	THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+	WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+	MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+	ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+	WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+	ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+	OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+	*/
 	public mutating func random64(max: UInt64) -> UInt64 {
+		if max < 2 {
+			return 0
+		}
+		
 		var result: UInt64
+		let min: UInt64 = UInt64.max % max
+		
 		repeat {
 			result = random64()
-		} while result > max
-		return result
+		} while result < min
+		
+		return result % max
 	}
+	
 	public mutating func random32(max: UInt32) -> UInt32 {
+		if max < 2 {
+			return 0
+		}
+		
 		var result: UInt32
+		let min: UInt32 = UInt32.max % max
+		
 		repeat {
 			result = random32()
-		} while result > max
-		return result
+		} while result < min
+		
+		return result % max
 	}
+	
 	public mutating func randomHalfOpen() -> Double {
 		return halfOpenDoubleFrom64(random64())
 	}


### PR DESCRIPTION
When  called with  very  small  max values,  the  previous random32  &
random64 implementations  could take  a very long  time to  generate a
valid number. This  patch reimplements BSD's arc4random_uniform method
to  avoid thinking  about when  to  use this  method and  when to  use
.random32/64() % smallNumber. See http://stackoverflow.com/a/20051580.
