### PR TITLE
Add missed destroy method call for mutex attributes

### DIFF
--- a/Sources/CwlUtils/CwlMutex.swift
+++ b/Sources/CwlUtils/CwlMutex.swift
@@ -97,6 +97,7 @@ public final class PThreadMutex: RawMutex {
 		guard pthread_mutex_init(&unsafeMutex, &attr) == 0 else {
 			preconditionFailure()
 		}
+		pthread_mutexattr_destroy(&attr)
 	}
 	
 	deinit {


### PR DESCRIPTION
I don't know if you missed this step or decided to not call this method. But it's better to do so since API provides us this method.