### PR TITLE
Support for 32/bit Linux

### DIFF
--- a/Sources/CwlUtils/CwlMutex.swift
+++ b/Sources/CwlUtils/CwlMutex.swift
@@ -20,6 +20,10 @@
 
 import Foundation
 
+#if os(Linux)
+import Dispatch
+#endif
+
 /// A basic mutex protocol that requires nothing more than "performing work inside the mutex".
 public protocol ScopedMutex {
 	/// Perform work inside the mutex
@@ -90,9 +94,9 @@ public final class PThreadMutex: RawMutex {
 		}
 		switch type {
 		case .normal:
-			pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_NORMAL)
+			pthread_mutexattr_settype(&attr, Int32(PTHREAD_MUTEX_NORMAL))
 		case .recursive:
-			pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE)
+			pthread_mutexattr_settype(&attr, Int32(PTHREAD_MUTEX_RECURSIVE))
 		}
 		guard pthread_mutex_init(&unsafeMutex, &attr) == 0 else {
 			preconditionFailure()


### PR DESCRIPTION
I found a few minor compilation issues in `CwlMutex.swift`when it was added to my project (32-bit Linux.) I only imported the one file (according to the note on your blog) so it is the only file tested. (Unfortunately, my cross-compilation setup requires a rather complicated makefile to build anything so it is somewhat non-trivial to test your entire project.)

Thought I'd send along the few small changes in case you wanted them.