### PR TITLE
Make blocks escaping to avoid new error in Xcode 10

### DIFF
--- a/Sources/CwlUtils/CwlScalarScanner.swift
+++ b/Sources/CwlUtils/CwlScalarScanner.swift
@@ -114,7 +114,7 @@ public struct ScalarScanner<C: Collection> where C.Iterator.Element == UnicodeSc
 	}
 	
 	/// Throw if the next scalar at the current `index` fails to match the next scalar in `scalars`. Advance the `index` to the end of the match.
-	public mutating func match(where test: (UnicodeScalar) -> Bool) throws {
+	public mutating func match(where test: @escaping (UnicodeScalar) -> Bool) throws {
 		if index == scalars.endIndex || !test(scalars[index]) {
 			throw ScalarScannerError.matchFailed(wanted: String(describing: test), at: consumed)
 		}
@@ -123,7 +123,7 @@ public struct ScalarScanner<C: Collection> where C.Iterator.Element == UnicodeSc
 	}
 	
 	/// Throw if the scalars at the current `index` don't match the scalars in `value`. Advance the `index` to the end of the match.
-	mutating func read(where test: (UnicodeScalar) -> Bool) throws -> UnicodeScalar {
+	mutating func read(where test: @escaping (UnicodeScalar) -> Bool) throws -> UnicodeScalar {
 		if index == scalars.endIndex || !test(scalars[index]) {
 			throw ScalarScannerError.matchFailed(wanted: String(describing: test), at: consumed)
 		}


### PR DESCRIPTION
In Xcode 10, String(describing: Subject) now throws a warning for blocks indicating that they may escape.

I don't know if this is an appropriate fix for these methods (Not quire sure what the string value should be in these cases), but I assumed others might run into similar issues so I decided to submit a PR with this tiny change.